### PR TITLE
ci(syntax): fix deprecated actions syntax. Fixes #6

### DIFF
--- a/.github/workflows/shabbat_api_released.yml
+++ b/.github/workflows/shabbat_api_released.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get new version from the event
         id: new_version
-        run: echo "::set-output name=text::${{ github.event.client_payload.release }}" | xargs
+        run: echo "text=${{ github.event.client_payload.release }}" | xargs > $GITHUB_OUTPUT
 
       - name: Configure git
         run: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description
Remove usage of `set-output` on the Github Actions Workflows
### Describe what you did and why.
I followed the specs on the issue with the `help wanted` label
**Related issue (if any):** fixes #6

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
